### PR TITLE
Updated `drop` to prevent stack overflows.

### DIFF
--- a/benchmark/Main.elm
+++ b/benchmark/Main.elm
@@ -1,0 +1,21 @@
+module Main exposing (..)
+
+import Benchmark exposing (..)
+import Benchmark.Runner exposing (BenchmarkProgram, program)
+import Lazy.List exposing (..)
+
+
+suite : Benchmark
+suite =
+    describe "Lazy.List"
+        [ benchmark "drop" <|
+            \_ ->
+                numbers
+                    |> drop 500
+                    |> head
+        ]
+
+
+main : BenchmarkProgram
+main =
+    program suite

--- a/benchmark/elm-package.json
+++ b/benchmark/elm-package.json
@@ -1,0 +1,18 @@
+{
+    "version": "1.0.0",
+    "summary": "helpful summary of your project, less than 80 characters",
+    "repository": "https://github.com/user/project.git",
+    "license": "BSD3",
+    "source-directories": [
+        ".",
+        "../src"
+    ],
+    "exposed-modules": [],
+    "dependencies": {
+        "BrianHicks/elm-benchmark": "2.0.3 <= v < 3.0.0",
+        "eeue56/elm-lazy": "1.0.0 <= v < 2.0.0",
+        "elm-lang/core": "5.1.1 <= v < 6.0.0",
+        "elm-lang/html": "2.0.0 <= v < 3.0.0"
+    },
+    "elm-version": "0.18.0 <= v < 0.19.0"
+}

--- a/src/Lazy/List.elm
+++ b/src/Lazy/List.elm
@@ -287,8 +287,8 @@ takeWhile predicate list =
 -}
 drop : Int -> LazyList a -> LazyList a
 drop n list =
-    lazy <|
-        \() ->
+    let
+        dropHelper n list =
             if n <= 0 then
                 force list
             else
@@ -297,7 +297,11 @@ drop n list =
                         Nil
 
                     Cons first rest ->
-                        force (drop (n - 1) rest)
+                        dropHelper (n - 1) rest
+    in
+    lazy <|
+        \() ->
+            dropHelper n list
 
 
 {-| Drop elements from a list as long as the predicate is satisfied.

--- a/tests/Example.elm
+++ b/tests/Example.elm
@@ -1,7 +1,7 @@
 module Example exposing (..)
 
 import Expect exposing (Expectation)
-import Fuzz exposing (Fuzzer, list, int, string)
+import Fuzz exposing (Fuzzer, int, intRange, list, string)
 import Test exposing (..)
 import Lazy.List exposing (..)
 
@@ -28,5 +28,13 @@ suite =
                     |> cons 6
                     |> sum
                     |> Expect.equal 16
+            )
+        , fuzz (intRange 0 4000)
+            "Drop should drop exactly n elements"
+            (\n ->
+                numbers
+                    |> drop n
+                    |> head
+                    |> Expect.equal (Just (n + 1))
             )
         ]


### PR DESCRIPTION
This is done using a helper method where the recursion can be optimized away by the elm compiler.

With the original version, since most (all?) browsers do not support tail call optimisation, dropping many elements would eventually overflow the stack. With the new helper function the elm compiler can restructure the function into a loop which does not have the same problem.

As an added bonus it is apparently quite a bit [faster](https://gist.github.com/peacememories/4d33a82a5b8734eb752ea8cdcca79c5c).

Fixes #5