### PR TITLE
Update `dropWhile` to protect against stack overflows and improve performance

### DIFF
--- a/benchmark/Main.elm
+++ b/benchmark/Main.elm
@@ -13,6 +13,11 @@ suite =
                 numbers
                     |> drop 500
                     |> head
+        , benchmark "dropWhile" <|
+            \_ ->
+                numbers
+                    |> dropWhile (\x -> x < 500)
+                    |> head
         ]
 
 

--- a/src/Lazy/List.elm
+++ b/src/Lazy/List.elm
@@ -308,17 +308,21 @@ drop n list =
 -}
 dropWhile : (a -> Bool) -> LazyList a -> LazyList a
 dropWhile predicate list =
-    lazy <|
-        \() ->
+    let
+        dropHelper list =
             case force list of
                 Nil ->
                     Nil
 
                 Cons first rest ->
                     if predicate first then
-                        force (dropWhile predicate rest)
+                        dropHelper rest
                     else
-                        force list
+                        Cons first rest
+    in
+    lazy <|
+        \() ->
+            dropHelper list
 
 
 {-| Test if a value is a member of a list.

--- a/tests/Example.elm
+++ b/tests/Example.elm
@@ -37,4 +37,21 @@ suite =
                     |> head
                     |> Expect.equal (Just (n + 1))
             )
+        , describe "dropWhile"
+            [ fuzz (intRange 1 4000)
+                "should drop all elements that match the predicate"
+                (\n ->
+                    numbers
+                        |> dropWhile (\x -> x < n)
+                        |> head
+                        |> Expect.equal (Just n)
+                )
+            , test "should not overflow the stack"
+                (\_ ->
+                    numbers
+                        |> dropWhile (\x -> x < 10000)
+                        |> head
+                        |> Expect.equal (Just 10000)
+                )
+            ]
         ]


### PR DESCRIPTION
This change is very similar to the one concerning `drop`.
As expected, the speedup is very similar too. This time I've also added a test case for the stack overflow, which should probably happen for `drop` too.

I have a question for editing: which version of `elm-format` was used for `elm-lazy-list`? I've used `latest` and `exp`, but both reformat whole files, making it more difficult to pull out the real changes.