### PR TITLE
Update `unique` to fix stack overflow.

### DIFF
--- a/benchmark/Main.elm
+++ b/benchmark/Main.elm
@@ -18,6 +18,12 @@ suite =
                 numbers
                     |> dropWhile (\x -> x < 500)
                     |> head
+        , benchmark "unique" <|
+            \_ ->
+                repeat 5
+                    |> take 500
+                    |> unique
+                    |> head
         ]
 
 

--- a/src/Lazy/List.elm
+++ b/src/Lazy/List.elm
@@ -350,17 +350,21 @@ length =
 -}
 unique : LazyList a -> LazyList a
 unique list =
-    lazy <|
-        \() ->
+    let
+        uniqueHelper list =
             case force list of
                 Nil ->
                     Nil
 
                 Cons first rest ->
                     if member first rest then
-                        force (unique rest)
+                        uniqueHelper rest
                     else
                         Cons first (unique rest)
+    in
+    lazy <|
+        \() ->
+            uniqueHelper list
 
 
 {-| Keep all elements in a list that satisfy the given predicate.

--- a/tests/Example.elm
+++ b/tests/Example.elm
@@ -54,4 +54,22 @@ suite =
                         |> Expect.equal (Just 10000)
                 )
             ]
+        , describe "unique"
+            [ test "should drop all non-uniqe elements"
+                (\_ ->
+                    interleave numbers numbers
+                        |> take (2 * 500)
+                        |> unique
+                        |> length
+                        |> Expect.equal 500
+                )
+            , test "should not overflow the stack"
+                (\_ ->
+                    repeat 5
+                        |> take 10000
+                        |> unique
+                        |> head
+                        |> Expect.equal (Just 5)
+                )
+            ]
         ]


### PR DESCRIPTION
Here the performance benefit is much smaller than in previous examples.