### PR TITLE
Fix stack overflow in toList

### DIFF
--- a/benchmark/Main.elm
+++ b/benchmark/Main.elm
@@ -24,6 +24,11 @@ suite =
                     |> take 500
                     |> unique
                     |> head
+        , benchmark "toList" <|
+            \_ ->
+                numbers
+                    |> take 500
+                    |> toList
         ]
 
 

--- a/src/Lazy/List.elm
+++ b/src/Lazy/List.elm
@@ -700,12 +700,17 @@ product5 list1 list2 list3 list4 list5 =
 -}
 toList : LazyList a -> List a
 toList list =
-    case force list of
-        Nil ->
-            []
+    let
+        toReverseList list accumulator =
+            case force list of
+                Nil ->
+                    accumulator
 
-        Cons first rest ->
-            first :: toList rest
+                Cons first rest ->
+                    toReverseList rest (first :: accumulator)
+    in
+    toReverseList list []
+        |> List.reverse
 
 
 {-| Convert a normal list to a lazy list.

--- a/tests/Example.elm
+++ b/tests/Example.elm
@@ -29,6 +29,14 @@ suite =
                     |> sum
                     |> Expect.equal 16
             )
+        , test "toList should not overflow the stack"
+            (\_ ->
+                Lazy.List.numbers
+                    |> Lazy.List.take 100000
+                    |> Lazy.List.toList
+                    |> List.length
+                    |> Expect.equal 100000
+            )
         , fuzz (intRange 0 4000)
             "Drop should drop exactly n elements"
             (\n ->


### PR DESCRIPTION
This pull request fixes a stack overflow vulnerability in `toList`
This comes at a performance cost, which could be alleviated by a technique described in https://github.com/zwilias/elm-faster-map