### PR TITLE
Fix overflow issues

### DIFF
--- a/src/Lazy/List.elm
+++ b/src/Lazy/List.elm
@@ -753,12 +753,7 @@ fromList =
 -}
 toArray : LazyList a -> Array a
 toArray list =
-    case force list of
-        Nil ->
-            Array.empty
-
-        Cons first rest ->
-            Array.append (Array.push first Array.empty) (toArray rest)
+    foldl Array.push Array.empty list
 
 
 {-| Convert an array to a lazy list.

--- a/src/Lazy/List.elm
+++ b/src/Lazy/List.elm
@@ -470,7 +470,7 @@ foldl =
 -}
 foldr : (a -> b -> b) -> b -> LazyList a -> b
 foldr reducer b list =
-    Array.foldr reducer b (toArray list)
+    List.foldl reducer b <| foldl (::) [] list
 
 
 {-| Get the sum of a list of numbers.

--- a/src/Lazy/List.elm
+++ b/src/Lazy/List.elm
@@ -362,7 +362,10 @@ member a list =
             False
 
         Cons first rest ->
-            first == a || member a rest
+            if first == a then
+                True
+            else
+                member a rest
 
 
 {-| Get the length of a lazy list.

--- a/src/Lazy/List.elm
+++ b/src/Lazy/List.elm
@@ -734,12 +734,7 @@ product5 list1 list2 list3 list4 list5 =
 -}
 toList : LazyList a -> List a
 toList list =
-    case force list of
-        Nil ->
-            []
-
-        Cons first rest ->
-            first :: toList rest
+    foldr (::) [] list
 
 
 {-| Convert a normal list to a lazy list.

--- a/tests/Example.elm
+++ b/tests/Example.elm
@@ -1,5 +1,6 @@
 module Example exposing (..)
 
+import Array
 import Expect exposing (Expectation)
 import Fuzz exposing (Fuzzer, int, intRange, list, string)
 import Lazy.List exposing (..)
@@ -71,5 +72,85 @@ suite =
                         |> head
                         |> Expect.equal (Just 5)
                 )
+            ]
+        , describe "toArray"
+            [ test "should correctly convert a list" <|
+                let
+                    reference =
+                        Array.fromList <| List.range 1 10
+
+                    input =
+                        fromArray reference
+                in
+                \_ ->
+                    input
+                        |> toArray
+                        |> Expect.equal reference
+            , test "should not overflow the stack" <|
+                \_ ->
+                    repeat 5
+                        |> take 10000
+                        |> toArray
+                        |> always Expect.pass
+            ]
+        , describe "toList"
+            [ test "should correctly convert a list" <|
+                let
+                    reference =
+                        List.range 1 10
+
+                    input =
+                        fromList reference
+                in
+                \_ ->
+                    input
+                        |> toList
+                        |> Expect.equal reference
+            , test "should not overflow the stack" <|
+                \_ ->
+                    repeat 5
+                        |> take 100000
+                        |> toList
+                        |> always Expect.pass
+            ]
+        , describe "foldr"
+            [ test "should fold in the right direction" <|
+                let
+                    reference =
+                        List.range 1 10
+
+                    input =
+                        fromList reference
+                in
+                \_ ->
+                    input
+                        |> foldr (::) []
+                        |> Expect.equal reference
+            , test "should not overflow the stack" <|
+                \_ ->
+                    repeat 5
+                        |> take 10000
+                        |> foldr (+) 0
+                        |> always Expect.pass
+            ]
+        , describe "member"
+            [ test "should find a value in a list" <|
+                \_ ->
+                    numbers
+                        |> take 5
+                        |> member 3
+                        |> Expect.equal True
+            , test "should not find a value that is not in the list" <|
+                \_ ->
+                    numbers
+                        |> take 5
+                        |> member 10
+                        |> Expect.equal False
+            , test "should not overflow the stack" <|
+                \_ ->
+                    numbers
+                        |> take 10000
+                        |> member -1
+                        |> always Expect.pass
             ]
         ]


### PR DESCRIPTION
This fixes overflow risks in `member`, `foldr`, `toArray` and `toList`.

# Performance changes

## `member`

Ellie: https://ellie-app.com/cp8pGTSqka1/0

Not very significant, but we see small performance improvements of a few percent

## `foldr`

Ellie: https://ellie-app.com/cqTX3hTZha1/0

Here we see large improvements by up to 5x (at a size of 1000) in addition to the gained safety

## `toArray`

Ellie: https://ellie-app.com/cqTX3hTZha1/1

Again, substantial improvements in performance of 2x or more in Safari, 3.5x in Chrome (at 100 elements, because the old implementation crashed at 1000 elements)

## `toList`

Ellie: https://ellie-app.com/b8LwvzJTDa1/0

Here the story becomes less positive. The new implementation is essentially the same as proposed in the last pull request, just less verbose because `foldr` was used instead of manual recursion.
The function is safe, but on average about 10% slower than the original.
The Ellie above also contains a comparison between the original `toList` and a version using the original `foldr` instead of the new, faster one.

In addition, the benchmarks vary between machines and between browsers.

On my MacBook, Safari had about a -5% performance difference, Chrome Canary about -10% while Firefox Developer Edition was at about -36% (granted, Firefox's performance was generally about half of the other browsers)

On my Windows desktop Chrome Canary as well as Firefox managed about -10%.

I'm not sure this can be faster without a significant restructuring of the library (maybe adding chunking would increase performance, but I don't think this library should make a decision about this on behalf of its users?). I managed to get the benchmarks on my Desktop to about -7% by running the original algorithm for the first 1000 steps, but this would make the code less readable for a very minor improvement.

